### PR TITLE
Fix togglewifi: interpolate Interface variable

### DIFF
--- a/bin/Darwin/togglewifi
+++ b/bin/Darwin/togglewifi
@@ -18,10 +18,10 @@ set Interface to "en0"
 set NetworkStatus to (do shell script "networksetup -getairportnetwork " & Interface)
 if (NetworkStatus contains "off") then
   # turn Wi-Fi on
-  do shell script "networksetup -setairportpower Interface on"
+  do shell script "networksetup -setairportpower " & Interface & " on"
   do shell script "echo Wi-Fi turned on"
 else
   # turn Wi-Fi off
-  do shell script "networksetup -setairportpower Interface off"
+  do shell script "networksetup -setairportpower " & Interface & " off"
   do shell script "echo Wi-Fi turned off"
 end if


### PR DESCRIPTION
The `Interface` variable on lines 21 and 24 is inside a quoted string, so AppleScript treats it as the literal string "Interface" rather than the value of the variable ("en0"). The `networksetup -setairportpower` calls never actually reference the right interface.

Fixed by concatenating the variable into the command string with `&`.