### PR TITLE
Fix switch_bash: use grep -F instead of -f

### DIFF
--- a/autoloaded/switch_bash
+++ b/autoloaded/switch_bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 BREW_PREFIX=$(brew --prefix)
-if ! grep -fq "${BREW_PREFIX}/bin/bash" /etc/shells; then
+if ! grep -Fq "${BREW_PREFIX}/bin/bash" /etc/shells; then
   echo "${BREW_PREFIX}/bin/bash" | sudo tee -a /etc/shells;
   chsh -s "${BREW_PREFIX}/bin/bash";
 else


### PR DESCRIPTION
`grep -fq` on line 4 tells grep to read patterns from a file (`-f`), so it tries to parse the bash binary as a pattern file. This should be `grep -Fq` (fixed string match) to check whether the Homebrew bash path is already in `/etc/shells`.

One character fix: `-f` → `-F`.